### PR TITLE
[CHORE] Add Dependabot config and CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "bot"
+    commit-message:
+      prefix: "[CHORE](deps)"
+      include: "scope"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @overturemaps/omf-public-reviewers


### PR DESCRIPTION
Add .github/dependabot.yml to enable weekly Dependabot updates for GitHub Actions (limit 5 open PRs, label PRs as "bot", and use commit-message prefix "[CHORE](deps)"). Also add a CODEOWNERS file that assigns repository-wide ownership to @overturemaps/omf-public-reviewers to ensure default reviewers are requested for changes.

Partially resolves https://github.com/OvertureMaps/ops-team/issues/273